### PR TITLE
Replace Plesk placeholder with custom landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,28 +1,42 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
 <head>
-    <meta charset="utf-8">
-    <title>Domain Default page</title>
-    <meta name="copyright" content="Copyright 1999-2024. WebPros International GmbH. All rights reserved.">
-    <script src="https://assets.plesk.com/static/default-website-content/public/default-website-index.js"></script>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Palópoli & Albrecht</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f4f4f4;
+      color: #333;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+    .container {
+      text-align: center;
+      background: #fff;
+      padding: 2rem 3rem;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      border-radius: 8px;
+    }
+    h1 {
+      margin-top: 0;
+      color: #2c3e50;
+    }
+    a {
+      color: #0077cc;
+    }
+  </style>
 </head>
 <body>
-    <h2>What is Plesk</h2>
-    <p>
-        Plesk is a <a href="https://www.plesk.com">hosting panel</a> with simple and secure web server, website and web apps management tools. It is specially designed to help web professionals manage web, DNS, mail and other services through a comprehensive and user-friendly GUI. Plesk is about intelligently managing servers, apps, websites and hosting businesses, on both traditional and cloud hosting.
-    </p>
-    <p>
-        <a href="https://docs.plesk.com/try-plesk-now/">Try Plesk Now!</a>
-    </p>
-    <ul>
-        <li><a href="https://docs.plesk.com/en-US/obsidian/">Plesk Guides</a></li>
-        <li><a href="https://support.plesk.com/hc/en-us">Knowledge Base</a></li>
-        <li><a href="https://talk.plesk.com/">Forum</a></li>
-        <li><a href="https://www.plesk.com/blog/">Blog</a></li>
-        <li><a href="https://www.youtube.com/channel/UCeU-_6YHGQFcVSHLbEXLNlA/playlists">Video Guides</a></li>
-        <li><a href="https://www.facebook.com/Plesk">Facebook</a></li>
-    </ul>
-
-    <p>Do you host WordPress sites outside of Plesk? Try <a href="https://wpguardian.io/">WP Guardian</a> - it provides complete visibility into the health of your WordPress websites in one place and keeps them protected with flexible updates management</p>
+  <div class="container">
+    <h1>Palópoli & Albrecht</h1>
+    <p>Nosso site está em desenvolvimento.</p>
+    <p>Entre em contato via <a href="mailto:contato@palopoliadv.com.br">contato@palopoliadv.com.br</a>.</p>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace default Plesk index.html with simple Palópoli & Albrecht landing page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b88f8b6e9083308b47acf24ee99d5a